### PR TITLE
Allow "Raindropio" or "Raindrop.io" to be given as App:Bookmarking:Service

### DIFF
--- a/BookmarkSync.Infrastructure.Tests/Services/BookmarkingServiceTests.cs
+++ b/BookmarkSync.Infrastructure.Tests/Services/BookmarkingServiceTests.cs
@@ -113,4 +113,30 @@ public class BookmarkingServiceTests
         Assert.AreEqual(typeof(RaindropioBookmarkingService), obj.GetType());
         Assert.IsInstanceOfType(obj, typeof(RaindropioBookmarkingService));
     }
+    [TestMethod]
+    public void GetBookmarkingService_Raindropio2()
+    {
+        // Arrange
+        var config = new Dictionary<string, string?>
+        {
+            {
+                "App:Bookmarking:Service", "Raindrop.io"
+            },
+            {
+                "App:Bookmarking:ApiToken", "228CCE89-7E7B-4D15-936A-39892AE86110"
+            }
+        };
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(config)
+            .Build();
+
+        IConfigManager configManager = new ConfigManager(configuration);
+
+        // Act
+        var obj = BookmarkingService.GetBookmarkingService(configManager);
+
+        // Assert
+        Assert.AreEqual(typeof(RaindropioBookmarkingService), obj.GetType());
+        Assert.IsInstanceOfType(obj, typeof(RaindropioBookmarkingService));
+    }
 }

--- a/BookmarkSync.Infrastructure/Services/Bookmarking/BookmarkingService.cs
+++ b/BookmarkSync.Infrastructure/Services/Bookmarking/BookmarkingService.cs
@@ -37,7 +37,7 @@ public abstract class BookmarkingService
         {
             "LinkAce" => new LinkAceBookmarkingService(configManager),
             "Pinboard" => new PinboardBookmarkingService(configManager),
-            "Raindropio" => new RaindropioBookmarkingService(configManager),
+            "Raindropio" or "Raindrop.io" => new RaindropioBookmarkingService(configManager),
             _ => throw new InvalidOperationException("Bookmark service either not provided or unknown")
         };
     }


### PR DESCRIPTION
Allows

```json
...
"App": {
    "Bookmarking": {
      "Service": "Raindropio",
      "ApiToken": "bc61de8f-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
    }
...
```

or

```json
...
"App": {
    "Bookmarking": {
      "Service": "Raindrop.io",
      "ApiToken": "bc61de8f-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
    }
...
```

to be valid.