### PR TITLE
Split standard app config from production configs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,6 @@
 ## Get latest from https://github.com/github/gitignore/blob/main/VisualStudio.gitignore
 
 # Secrets
-appsettings.json
 appsettings.*.json
 !appsettings.Example.json
 

--- a/.run/BookmarkSync.CLI.run.xml
+++ b/.run/BookmarkSync.CLI.run.xml
@@ -4,6 +4,9 @@
     <option name="PROGRAM_PARAMETERS" value="" />
     <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/BookmarkSync.CLI/bin/Debug/net7.0" />
     <option name="PASS_PARENT_ENVS" value="1" />
+    <envs>
+      <env name="MBS_ENVIRONMENT" value="Development" />
+    </envs>
     <option name="USE_EXTERNAL_CONSOLE" value="0" />
     <option name="USE_MONO" value="0" />
     <option name="RUNTIME_ARGUMENTS" value="" />

--- a/BookmarkSync.CLI/BookmarkSync.CLI.csproj
+++ b/BookmarkSync.CLI/BookmarkSync.CLI.csproj
@@ -36,10 +36,9 @@
     </ItemGroup>
 
     <ItemGroup>
-      <None Remove="appsettings.Development.json" />
-      <Content Include="appsettings.Development.json">
+      <None Include="appsettings.Development.json" Condition="Exists('appsettings.Development.json')">
         <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-      </Content>
+      </None>
     </ItemGroup>
 
 </Project>

--- a/BookmarkSync.CLI/BookmarkSync.CLI.csproj
+++ b/BookmarkSync.CLI/BookmarkSync.CLI.csproj
@@ -35,4 +35,11 @@
       </None>
     </ItemGroup>
 
+    <ItemGroup>
+      <None Remove="appsettings.Development.json" />
+      <Content Include="appsettings.Development.json">
+        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      </Content>
+    </ItemGroup>
+
 </Project>

--- a/BookmarkSync.CLI/Program.cs
+++ b/BookmarkSync.CLI/Program.cs
@@ -50,6 +50,7 @@ public static class Program
             .Build();
     private static IConfiguration SetupConfiguration(string[] args) => new ConfigurationBuilder()
         .AddJsonFile("appsettings.json", false, true)
+        .AddJsonFile($"appsettings.{Environment.GetEnvironmentVariable("MBS_ENVIRONMENT") ?? "Production"}.json", false, true)
         .AddEnvironmentVariables()
         .AddCommandLine(args)
         .Build();

--- a/BookmarkSync.CLI/appsettings.Example.json
+++ b/BookmarkSync.CLI/appsettings.Example.json
@@ -12,26 +12,5 @@
       "ApiToken": "",
       "LinkAceUri": ""
     }
-  },
-  "Serilog": {
-    "Using": [
-      "Serilog.Sinks.Console"
-    ],
-    "MinimumLevel": {
-      "Default": "Information",
-      "Override": {
-        "Microsoft": "Warning",
-        "System": "Error"
-      }
-    },
-    "WriteTo": [
-      {
-        "Name": "Console",
-        "Args": {
-          "theme": "Serilog.Sinks.SystemConsole.Themes.AnsiConsoleTheme::Code, Serilog.Sinks.Console",
-          "outputTemplate": "{Timestamp:yyyy-MM-dd HH:mm:ss.fff zzz} [{Level}] [{SourceContext}] [{EventId}] {Message}{NewLine}{Exception}"
-        }
-      }
-    ]
   }
 }

--- a/BookmarkSync.CLI/appsettings.json
+++ b/BookmarkSync.CLI/appsettings.json
@@ -1,0 +1,23 @@
+{
+  "Serilog": {
+    "Using": [
+      "Serilog.Sinks.Console"
+    ],
+    "MinimumLevel": {
+      "Default": "Information",
+      "Override": {
+        "Microsoft": "Warning",
+        "System": "Error"
+      }
+    },
+    "WriteTo": [
+      {
+        "Name": "Console",
+        "Args": {
+          "theme": "Serilog.Sinks.SystemConsole.Themes.AnsiConsoleTheme::Code, Serilog.Sinks.Console",
+          "outputTemplate": "{Timestamp:yyyy-MM-dd HH:mm:ss.fff zzz} [{Level}] [{SourceContext}] {Message}{NewLine}{Exception}"
+        }
+      }
+    ]
+  }
+}

--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ it. An example configuration can be found [here][config-blob]. You can also
 just copy the example:
 
 ```shell
-cp appsettings.Example.json appsettings.json
-vim appsettings.json # don't forget to edit it!
+cp appsettings.Example.json appsettings.Production.json
+vim appsettings.Production.json # don't forget to edit it!
 ```
 
 You'll need an access token from your Mastodon server.


### PR DESCRIPTION
This improves our ability to change standard app configuration without causing issues when upgrading.

However, if you already have a configured `appsettings.json`, you'll have to move the `Instances` and `App` configurations to a new `appsettings.Production.json`. 